### PR TITLE
 fix(🐞): object syntax and esm

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ function writeEsmModules(args, modules) {
 
     // 🚧 For Electron-Renderer
     const cjsModule = require(moduleCjsId);
-    const requireModule = `const _M_ = require("${CACHE_DIR}/${mod}");`;
+    const requireModule = `const _M_ = require("${CACHE_DIR}/${moduleName}");`;
     const exportDefault = `const _D_ = _M_.default || _M_;\nexport { _D_ as default };`;
     const exportMembers = Object
       .keys(cjsModule)


### PR DESCRIPTION
Otherwise, the file ends up writing something like

```js
const _M_ = require(".vite-plugin-esmodule/[object Object]");
```