### PR TITLE
V1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [2022-07-26] v1.4.2
+
+- 7e2c787 docs: v1.4.2
+- 9ca00dc refactor: better type define
+- b0e56ef refactor: `modules` support function
+
 ## [2022-07-12] v1.4.1
 
 - 8de5395  fix(🐞): object syntax and esm

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Build ES module to CommonJs module for Node.js/Electron
 
-[![NPM version](https://img.shields.io/npm/v/vite-plugin-esmodule.svg?style=flat)](https://npmjs.org/package/vite-plugin-esmodule)
-[![NPM Downloads](https://img.shields.io/npm/dm/vite-plugin-esmodule.svg?style=flat)](https://npmjs.org/package/vite-plugin-esmodule)
+[![NPM version](https://img.shields.io/npm/v/vite-plugin-esmodule.svg)](https://npmjs.org/package/vite-plugin-esmodule)
+[![NPM Downloads](https://img.shields.io/npm/dm/vite-plugin-esmodule.svg)](https://npmjs.org/package/vite-plugin-esmodule)
 
 ## Why 🤔
 
@@ -48,20 +48,24 @@ console.log(stdout);
 //=> 'unicorns'
 ```
 
-[👉 See test](https://github.com/vite-plugin/vite-plugin-esmodule/test)
+<!-- [👉 See test](https://github.com/vite-plugin/vite-plugin-esmodule/test) -->
 
 ## API
 
+`esmodule(modules[, webpack])`
+
 ```ts
-export interface Esmodule {
-  (
-    /**
-     * If modules are not passed in, ESM packages will be automatically obtained from package.json in process.cwd path
-     */
-    modules?: (string | { [module: string]: string })[],
-    webpack?: ((config: Configuration) => Configuration | void | Promise<Configuration | void>),
-  ): Plugin;
-}
+import type { Plugin } from 'vite'
+import type { Configuration } from 'webpack'
+
+export type ModuleRecord = string | { [module: string]: string }
+
+declare function exports(
+  modules: ModuleRecord[] | ((esmPkgs: string[]) => ModuleRecord[]),
+  webpack?: ((config: Configuration) => Configuration | void | Promise<Configuration | void>),
+): Plugin
+
+export = exports
 ```
 
 ## How to work

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,11 @@
-import type { Plugin } from 'vite';
-import type { Configuration } from 'webpack';
+import type { Plugin } from 'vite'
+import type { Configuration } from 'webpack'
 
-export default esmodule;
-declare const esmodule: Esmodule;
+export type ModuleRecord = string | { [module: string]: string }
 
-export interface Esmodule {
-  (
-    /**
-     * If modules are not passed in, ESM packages will be automatically obtained from package.json in process.cwd path
-     */
-    modules?: (string | { [module: string]: string })[],
-    webpack?: ((config: Configuration) => Configuration | void | Promise<Configuration | void>),
-  ): Plugin;
-}
+declare function exports(
+  modules: ModuleRecord[] | ((esmPkgs: string[]) => ModuleRecord[]),
+  webpack?: ((config: Configuration) => Configuration | void | Promise<Configuration | void>),
+): Plugin
+
+export = exports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-esmodule",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Build ES module to CommonJs module for Node.js/Electron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### Chnages

- 7e2c787 docs: v1.4.2
- 9ca00dc refactor: better type define
- b0e56ef refactor: `modules` support function

#### Issues

[🐞 Some errors in playground/usecase-in-renderer #40](https://github.com/electron-vite/vite-plugin-electron/issues/40)

This errors is because `vite-plugin-esmodule` will automaticall build ESM modules in `package.json`, but some modules cannot be built normally. e.g. `vite`. Explicitly specifying which modules need to be built avoids the problem.
The next version of `vite-plugin-esmodule` will remove the auto-detection of ESM modules and leave it to the user to choose.

*该报错是由于 `vite-plugin-esmodule` 会自动构建 `package.json` 中的 ESM 模块，但是有些模块不能被正常的构建。比如 `vite`。显式的指定需要构建哪些模块，能避开这个问题。*
*`vite-plugin-esmodule` 的下一个版本将会移除自动检测 ESM 模块，交由用户自行选择。*
